### PR TITLE
upgrade FAIconPickerField to latest bolt version

### DIFF
--- a/src/Field/FAIconPickerField.php
+++ b/src/Field/FAIconPickerField.php
@@ -7,7 +7,6 @@ use Doctrine\DBAL\Types\Type;
 
 class FAIconPickerField extends FieldTypeBase
 {
-
     public function getName()
     {
         return 'faiconpicker';
@@ -25,6 +24,6 @@ class FAIconPickerField extends FieldTypeBase
 
     public function getStorageOptions()
     {
-        return ['default'=>''];
+        return ['default' => ''];
     }
 }


### PR DESCRIPTION
This fixes #9 
I upgraded the field type by extending the class `Bolt\Storage\Field\Type\FieldTypeBase` instead of implementing the interface `FieldTypeInterface`.
Also, the method `getStorageType` now uses Doctrine's factory method `getType` from `Doctrine\DBAL\Types`